### PR TITLE
修正搜索框补全问题

### DIFF
--- a/src/dde-file-manager-lib/views/dfmaddressbar.cpp
+++ b/src/dde-file-manager-lib/views/dfmaddressbar.cpp
@@ -426,8 +426,10 @@ void DFMAddressBar::initConnections()
 
         if (!DUrl::fromUserInput(str).isLocalFile()) {
             if (!historyList.contains(str)) {
-                historyList.append(str);
+                historyList.clear();
                 Singleton<SearchHistroyManager>::instance()->writeIntoSearchHistory(str);
+                historyList.append(Singleton<SearchHistroyManager>::instance()->toStringList());
+                completerModel.setStringList(historyList);
             }
         }
     });


### PR DESCRIPTION
搜索框当前窗口输入历史不能被正确引用，需要重新打开窗口才能被引用。这是个问题，需要修复。解决办法：在每次修改搜索历史后重新加载搜索记录。